### PR TITLE
Add a splay tree implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub mod iter;
 pub mod blist;
 pub mod immutslist;
 pub mod intervalheap;
-
+pub mod splay;

--- a/src/splay/map.rs
+++ b/src/splay/map.rs
@@ -1,0 +1,379 @@
+use std::borrow::BorrowFrom;
+use std::cell::UnsafeCell;
+use std::default::Default;
+use std::kinds::marker;
+use std::mem;
+
+use super::node::Node;
+
+/// The implementation of this splay tree is largely based on the c code at:
+///     ftp://ftp.cs.cmu.edu/usr/ftp/usr/sleator/splaying/top-down-splay.c
+/// This version of splaying is a top-down splay operation.
+pub struct SplayMap<K, V> {
+    root: UnsafeCell<Option<Box<Node<K, V>>>>,
+    size: uint,
+    marker: marker::NoSync, // lookups mutate the tree
+}
+
+pub struct IntoIter<K, V> {
+    cur: Option<Box<Node<K, V>>>,
+    remaining: uint,
+}
+
+/// Performs a top-down splay operation on a tree rooted at `node`. This will
+/// modify the pointer to contain the new root of the tree once the splay
+/// operation is done. When finished, if `key` is in the tree, it will be at the
+/// root. Otherwise the closest key to the specified key will be at the root.
+fn splay<K, V, Sized? Q>(key: &Q, node: &mut Box<Node<K, V>>)
+                         where K: Ord, Q: Ord + BorrowFrom<K>
+{
+    let mut newleft = None;
+    let mut newright = None;
+
+    // Eplicitly grab a new scope so the loans on newleft/newright are
+    // terminated before we move out of them.
+    {
+        // Yes, these are backwards, that's intentional.
+        let mut l = &mut newright;
+        let mut r = &mut newleft;
+
+        loop {
+            match key.cmp(BorrowFrom::borrow_from(&node.key)) {
+                // Found it, yay!
+                Equal => { break }
+
+                Less => {
+                    let mut left = match node.pop_left() {
+                        Some(left) => left, None => break
+                    };
+                    // rotate this node right if necessary
+                    if key.cmp(BorrowFrom::borrow_from(&left.key)) == Less {
+                        // A bit odd, but avoids drop glue
+                        mem::swap(&mut node.left, &mut left.right);
+                        mem::swap(&mut left, node);
+                        let none = mem::replace(&mut node.right, Some(left));
+                        match mem::replace(&mut node.left, none) {
+                            Some(l) => { left = l; }
+                            None    => { break }
+                        }
+                    }
+
+                    *r = Some(mem::replace(node, left));
+                    let tmp = r;
+                    r = &mut tmp.as_mut().unwrap().left;
+                }
+
+                // If you look closely, you may have seen some similar code
+                // before
+                Greater => {
+                    match node.pop_right() {
+                        None => { break }
+                        // rotate left if necessary
+                        Some(mut right) => {
+                            if key.cmp(BorrowFrom::borrow_from(&right.key)) == Greater {
+                                mem::swap(&mut node.right, &mut right.left);
+                                mem::swap(&mut right, node);
+                                let none = mem::replace(&mut node.left,
+                                                         Some(right));
+                                match mem::replace(&mut node.right, none) {
+                                    Some(r) => { right = r; }
+                                    None    => { break }
+                                }
+                            }
+                            *l = Some(mem::replace(node, right));
+                            let tmp = l;
+                            l = &mut tmp.as_mut().unwrap().right;
+                        }
+                    }
+                }
+            }
+        }
+
+        mem::swap(l, &mut node.left);
+        mem::swap(r, &mut node.right);
+    }
+
+    node.left = newright;
+    node.right = newleft;
+}
+
+impl<K: Ord, V> SplayMap<K, V> {
+    pub fn new() -> SplayMap<K, V> {
+        SplayMap{ root: UnsafeCell::new(None), size: 0, marker: marker::NoSync }
+    }
+
+    /// Moves all values out of this map, transferring ownership to the given
+    /// iterator.
+    pub fn into_iter(mut self) -> IntoIter<K, V> {
+        IntoIter { cur: self.root_mut().take(), remaining: self.size }
+    }
+
+    pub fn len(&self) -> uint { self.size }
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
+
+    /// Clears the tree in O(1) extra space (including the stack). This is
+    /// necessary to prevent stack exhaustion with extremely large trees.
+    pub fn clear(&mut self) {
+        let mut iter = IntoIter {
+            cur: self.root_mut().take(),
+            remaining: self.size,
+        };
+        for _ in iter {
+            // ignore, drop the values (and the node)
+        }
+        self.size = 0;
+    }
+
+    /// Return true if the map contains a value for the specified key
+    pub fn contains_key<Sized? Q>(&self, key: &Q) -> bool
+                                  where Q: Ord + BorrowFrom<K>
+    {
+        self.get(key).is_some()
+    }
+
+    /// Return a reference to the value corresponding to the key
+    pub fn get<Sized? Q>(&self, key: &Q) -> Option<&V>
+                         where Q: Ord + BorrowFrom<K>
+    {
+        // Splay trees are self-modifying, so they can't exactly operate with
+        // the immutable self given by the Map interface for this method. It can
+        // be guaranteed, however, that the callers of this method are not
+        // modifying the tree, they may just be rotating it. Each node is a
+        // pointer on the heap, so we know that none of the pointers inside
+        // these nodes (the value returned from this function) will be moving.
+        //
+        // With this in mind, we can unsafely use a mutable version of this tree
+        // to invoke the splay operation and return a pointer to the inside of
+        // one of the nodes (the pointer won't be deallocated or moved).
+        //
+        // However I'm not entirely sure whether this works with iteration or
+        // not. Arbitrary lookups can occur during iteration, and during
+        // iteration there's some form of "stack" remembering the nodes that
+        // need to get visited. I don't believe that it's safe to allow lookups
+        // while the tree is being iterated. Right now there are no iterators
+        // exposed on this splay tree implementation, and more thought would be
+        // required if there were.
+        unsafe {
+            match *self.root.get() {
+                Some(ref mut root) => {
+                    splay(key, root);
+                    if key == BorrowFrom::borrow_from(&root.key) {
+                        return Some(&root.value);
+                    }
+                    None
+                }
+                None => None,
+            }
+        }
+    }
+
+    /// Return a mutable reference to the value corresponding to the key
+    pub fn get_mut<Sized? Q>(&mut self, key: &Q) -> Option<&mut V>
+                             where Q: Ord + BorrowFrom<K>
+    {
+        match *self.root_mut() {
+            None => { return None; }
+            Some(ref mut root) => {
+                splay(key, root);
+                if key == BorrowFrom::borrow_from(&root.key) {
+                    return Some(&mut root.value);
+                }
+                return None;
+            }
+        }
+    }
+
+    /// Insert a key-value pair from the map. If the key already had a value
+    /// present in the map, that value is returned. Otherwise None is returned.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.root_mut() {
+            &Some(ref mut root) => {
+                splay(&key, root);
+
+                match key.cmp(&root.key) {
+                    Equal => {
+                        let old = mem::replace(&mut root.value, value);
+                        return Some(old);
+                    }
+                    /* TODO: would unsafety help perf here? */
+                    Less => {
+                        let left = root.pop_left();
+                        let new = Node::new(key, value, left, None);
+                        let prev = mem::replace(root, new);
+                        root.right = Some(prev);
+                    }
+                    Greater => {
+                        let right = root.pop_right();
+                        let new = Node::new(key, value, None, right);
+                        let prev = mem::replace(root, new);
+                        root.left = Some(prev);
+                    }
+                }
+            }
+            slot => {
+                *slot = Some(Node::new(key, value, None, None));
+            }
+        }
+        self.size += 1;
+        return None;
+    }
+
+    /// Removes a key from the map, returning the value at the key if the key
+    /// was previously in the map.
+    pub fn remove<Sized? Q>(&mut self, key: &Q) -> Option<V>
+                            where Q: BorrowFrom<K> + Ord {
+        match *self.root_mut() {
+            None => { return None; }
+            Some(ref mut root) => {
+                splay(key, root);
+                if key != BorrowFrom::borrow_from(&root.key) { return None }
+            }
+        }
+
+        // TODO: Extra storage of None isn't necessary
+        let (value, left, right) = match self.root_mut().take().unwrap() {
+            box Node {left, right, value, ..} => (value, left, right)
+        };
+
+        *self.root_mut() = match left {
+            None => right,
+            Some(mut node) => {
+                splay(key, &mut node);
+                node.right = right;
+                Some(node)
+            }
+        };
+
+        self.size -= 1;
+        return Some(value);
+    }
+}
+
+impl<K, V> SplayMap<K, V> {
+    // These two functions provide safe access to the root node, and they should
+    // be valid to call in virtually all contexts.
+    fn root_mut(&mut self) -> &mut Option<Box<Node<K, V>>> {
+        unsafe { &mut *self.root.get() }
+    }
+    fn root_ref(&self) -> &Option<Box<Node<K, V>>> {
+        unsafe { &*self.root.get() }
+    }
+}
+
+impl<K: Ord, V, Sized? Q> Index<Q, V> for SplayMap<K, V>
+    where Q: BorrowFrom<K> + Ord
+{
+    fn index(&self, index: &Q) -> &V {
+        self.get(index).expect("key not present in SplayMap")
+    }
+}
+
+impl<K: Ord, V, Sized? Q> IndexMut<Q, V> for SplayMap<K, V>
+    where Q: BorrowFrom<K> + Ord
+{
+    fn index_mut(&mut self, index: &Q) -> &mut V {
+        self.get_mut(index).expect("key not present in SplayMap")
+    }
+}
+
+impl<K: Ord, V> Default for SplayMap<K, V> {
+    fn default() -> SplayMap<K, V> { SplayMap::new() }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for SplayMap<K, V> {
+    fn from_iter<I: Iterator<(K, V)>>(iterator: I) -> SplayMap<K, V> {
+        let mut map = SplayMap::new();
+        map.extend(iterator);
+        map
+    }
+}
+
+impl<K: Ord, V> Extend<(K, V)> for SplayMap<K, V> {
+    fn extend<I: Iterator<(K, V)>>(&mut self, mut i: I) {
+        for (k, v) in i {
+            self.insert(k, v);
+        }
+    }
+}
+
+impl<K, V> Iterator<(K, V)> for IntoIter<K, V> {
+    fn next(&mut self) -> Option<(K, V)> {
+        let mut cur = match self.cur.take() {
+            Some(cur) => cur,
+            None => return None,
+        };
+        loop {
+            match cur.pop_left() {
+                Some(node) => {
+                    let mut node = node;
+                    cur.left = node.pop_right();
+                    node.right = Some(cur);
+                    cur = node;
+                }
+
+                None => {
+                    self.cur = cur.pop_right();
+                    // left and right fields are both None
+                    let node = *cur;
+                    let Node { key, value, .. } = node;
+                    self.remaining -= 1;
+                    return Some((key, value));
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (uint, Option<uint>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<K, V> DoubleEndedIterator<(K, V)> for IntoIter<K, V> {
+    // Pretty much the same as the above code, but with left replaced with right
+    // and vice-versa.
+    fn next_back(&mut self) -> Option<(K, V)> {
+        let mut cur = match self.cur.take() {
+            Some(cur) => cur,
+            None => return None,
+        };
+        loop {
+            match cur.pop_right() {
+                Some(node) => {
+                    let mut node = node;
+                    cur.right = node.pop_left();
+                    node.left = Some(cur);
+                    cur = node;
+                }
+
+                None => {
+                    self.cur = cur.pop_left();
+                    // left and right fields are both None
+                    let node = *cur;
+                    let Node { key, value, .. } = node;
+                    self.remaining -= 1;
+                    return Some((key, value));
+                }
+            }
+        }
+    }
+}
+
+impl<K, V> ExactSizeIterator<(K, V)> for IntoIter<K, V> {}
+
+impl<K: Clone, V: Clone> Clone for SplayMap<K, V> {
+    fn clone(&self) -> SplayMap<K, V> {
+        SplayMap {
+            root: UnsafeCell::new(self.root_ref().clone()),
+            size: self.size,
+            marker: self.marker.clone(),
+        }
+    }
+}
+
+#[unsafe_destructor]
+impl<K: Ord, V> Drop for SplayMap<K, V> {
+    fn drop(&mut self) {
+        // Be sure to not recurse too deep on destruction
+        self.clear();
+    }
+}

--- a/src/splay/mod.rs
+++ b/src/splay/mod.rs
@@ -1,0 +1,200 @@
+//! Contains an implementation of splay trees where each node has a key/value
+//! pair to be used in maps and sets. The only requirement is that the key must
+//! implement the Ord trait.
+//!
+//! # Example
+//!
+//! ```rust
+//! use collect::splay::SplayMap;
+//!
+//! let mut map = SplayMap::new();
+//! map.insert("foo", "bar");
+//! map.insert("hello", "world");
+//! map.insert("splay", "tree");
+//!
+//! for (k, v) in map.into_iter() {
+//!     println!("{} => {}", k, v);
+//! }
+//! ```
+
+pub use self::set::SplaySet;
+pub use self::map::SplayMap;
+
+pub mod set;
+pub mod map;
+mod node;
+
+#[cfg(test)]
+mod test {
+    use super::{SplayMap, SplaySet};
+
+    // Lots of these are shamelessly stolen from the TreeMap tests, it'd be
+    // awesome if they could share them...
+
+    #[test]
+    fn insert_simple() {
+        let mut t = SplayMap::new();
+        assert_eq!(t.insert(1i, 2i), None);
+        assert_eq!(t.insert(1, 3), Some(2));
+        assert_eq!(t.insert(2, 3), None);
+    }
+
+    #[test]
+    fn remove_simple() {
+        let mut t = SplayMap::new();
+        assert_eq!(t.insert(1i, 2i), None);
+        assert_eq!(t.insert(2, 3), None);
+        assert_eq!(t.insert(3, 4), None);
+        assert_eq!(t.insert(0, 5), None);
+        assert_eq!(t.remove(&1), Some(2));
+    }
+
+    #[test]
+    fn pop_simple() {
+        let mut t = SplayMap::new();
+        assert_eq!(t.insert(1i, 2i), None);
+        assert_eq!(t.insert(2, 3), None);
+        assert_eq!(t.insert(3, 4), None);
+        assert_eq!(t.insert(0, 5), None);
+        assert_eq!(t.remove(&1), Some(2));
+        assert_eq!(t.remove(&1), None);
+        assert_eq!(t.remove(&0), Some(5));
+    }
+
+    #[test]
+    fn find_mut_simple() {
+        let mut t = SplayMap::new();
+        assert_eq!(t.insert(1i, 2i), None);
+        assert_eq!(t.insert(2, 3), None);
+        assert_eq!(t.insert(3, 4), None);
+        assert_eq!(t.insert(0, 5), None);
+
+        {
+            let ptr = t.get_mut(&1);
+            assert!(ptr.is_some());
+            let ptr = ptr.unwrap();
+            assert_eq!(*ptr, 2);
+            *ptr = 4;
+        }
+
+        let ptr = t.get_mut(&1);
+        assert!(ptr.is_some());
+        assert_eq!(*ptr.unwrap(), 4);
+    }
+
+    #[test]
+    fn test_len() {
+        let mut m = SplayMap::new();
+        assert_eq!(m.insert(3i, 6i), None);
+        assert_eq!(m.len(), 1);
+        assert_eq!(m.insert(0, 0), None);
+        assert_eq!(m.len(), 2);
+        assert_eq!(m.insert(4, 8), None);
+        assert_eq!(m.len(), 3);
+        assert_eq!(m.remove(&3), Some(6));
+        assert_eq!(m.len(), 2);
+        assert_eq!(m.remove(&5), None);
+        assert_eq!(m.len(), 2);
+        assert_eq!(m.insert(2, 4), None);
+        assert_eq!(m.len(), 3);
+        assert_eq!(m.insert(1, 2), None);
+        assert_eq!(m.len(), 4);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut m = SplayMap::new();
+        m.clear();
+        assert_eq!(m.insert(5i, 11i), None);
+        assert_eq!(m.insert(12, -3), None);
+        assert_eq!(m.insert(19, 2), None);
+        m.clear();
+        assert_eq!(m.get(&5), None);
+        assert_eq!(m.get(&12), None);
+        assert_eq!(m.get(&19), None);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn insert_replace() {
+        let mut m = SplayMap::new();
+        assert_eq!(m.insert(5i, 2i), None);
+        assert_eq!(m.insert(2, 9), None);
+        assert_eq!(m.insert(2, 11), Some(9));
+        assert_eq!(m[2], 11);
+    }
+
+    #[test]
+    fn find_empty() {
+        let m: SplayMap<int, int> = SplayMap::new();
+        assert_eq!(m.get(&5), None);
+    }
+
+    #[test]
+    fn find_not_found() {
+        let mut m = SplayMap::new();
+        assert_eq!(m.insert(1i, 2i), None);
+        assert_eq!(m.insert(5, 3), None);
+        assert_eq!(m.insert(9, 3), None);
+        assert_eq!(m.get(&2), None);
+    }
+
+    #[test]
+    fn get_works() {
+        let mut m = SplayMap::new();
+        m.insert(1i, 1i);
+        assert_eq!(m[1], 1);
+    }
+
+    #[test]
+    fn into_iter() {
+        let mut m = SplayMap::new();
+        m.insert(1i, 1i);
+        m.insert(2, 1);
+        m.insert(0, 1);
+        let mut cur = 0;
+        for (k, v) in m.into_iter() {
+            assert_eq!(k, cur);
+            assert_eq!(v, 1);
+            cur += 1;
+        }
+    }
+
+    #[test]
+    fn into_iter_backwards() {
+        let mut m = SplayMap::new();
+        m.insert(1i, 1i);
+        m.insert(2, 1);
+        m.insert(0, 1);
+        let mut cur = 2;
+        for (k, v) in m.into_iter().rev() {
+            assert_eq!(k, cur);
+            assert_eq!(v, 1);
+            cur -= 1;
+        }
+    }
+
+    #[test] #[should_fail]
+    fn get_panic_works() {
+        let mut m = SplayMap::new();
+        m.insert(2i, 2i);
+        m[1];
+    }
+
+    #[test]
+    fn large() {
+        use std::rand::random;
+        let mut m = SplaySet::new();
+        let mut v = Vec::new();
+
+        for _ in range(0i, 400) {
+            let i: int = random();
+            m.insert(i);
+            v.push(i);
+        }
+
+        for i in v.iter() {
+            assert!(m.contains(i));
+        }
+    }
+}

--- a/src/splay/node.rs
+++ b/src/splay/node.rs
@@ -1,0 +1,27 @@
+use std::mem;
+
+#[deriving(Clone)]
+pub struct Node<K, V> {
+    pub key: K,
+    pub value: V,
+    pub left: Option<Box<Node<K, V>>>,
+    pub right: Option<Box<Node<K, V>>>,
+}
+
+impl<K, V> Node<K, V> {
+    pub fn new(k: K, v: V,
+               l: Option<Box<Node<K, V>>>,
+               r: Option<Box<Node<K, V>>>) -> Box<Node<K, V>> {
+        box Node{ key: k, value: v, left: l, right: r }
+    }
+
+    #[inline(always)]
+    pub fn pop_left(&mut self) -> Option<Box<Node<K, V>>> {
+        mem::replace(&mut self.left, None)
+    }
+
+    #[inline(always)]
+    pub fn pop_right(&mut self) -> Option<Box<Node<K, V>>> {
+        mem::replace(&mut self.right, None)
+    }
+}

--- a/src/splay/set.rs
+++ b/src/splay/set.rs
@@ -1,0 +1,78 @@
+use std::default::Default;
+use std::borrow::BorrowFrom;
+
+use super::map::{mod, SplayMap};
+
+#[deriving(Clone)]
+pub struct SplaySet<T> {
+    map: SplayMap<T, ()>
+}
+
+pub struct IntoIter<T> {
+    inner: map::IntoIter<T, ()>,
+}
+
+impl<T: Ord> SplaySet<T> {
+    /// Creates a new empty set
+    pub fn new() -> SplaySet<T> { SplaySet { map: SplayMap::new() } }
+
+    /// Moves all values out of this set, transferring ownership to the given
+    /// iterator.
+    pub fn into_iter(self) -> IntoIter<T> {
+        IntoIter { inner: self.map.into_iter() }
+    }
+
+    pub fn len(&self) -> uint { self.map.len() }
+    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn clear(&mut self) { self.map.clear() }
+
+    /// Return true if the set contains a value
+    pub fn contains<Sized? Q>(&self, item: &Q) -> bool
+                              where Q: BorrowFrom<T> + Ord {
+        self.map.contains_key(item)
+    }
+
+    /// Add a value to the set. Return true if the value was not already
+    /// present in the set.
+    pub fn insert(&mut self, t: T) -> bool {
+        self.map.insert(t, ()).is_none()
+    }
+
+    /// Remove a value from the set. Return true if the value was
+    /// present in the set.
+    pub fn remove<Sized? Q>(&mut self, item: &Q) -> bool
+                            where Q: BorrowFrom<T> + Ord {
+        self.map.remove(item).is_some()
+    }
+}
+
+impl<T> Iterator<T> for IntoIter<T> {
+    fn next(&mut self) -> Option<T> { self.inner.next().map(|p| p.val0()) }
+    fn size_hint(&self) -> (uint, Option<uint>) { self.inner.size_hint() }
+}
+
+impl<T> DoubleEndedIterator<T> for IntoIter<T> {
+    fn next_back(&mut self) -> Option<T> {
+        self.inner.next_back().map(|(k, _)| k)
+    }
+}
+
+impl<T> ExactSizeIterator<T> for IntoIter<T> {}
+
+impl<T: Ord> Default for SplaySet<T> {
+    fn default() -> SplaySet<T> { SplaySet::new() }
+}
+
+impl<T: Ord> FromIterator<T> for SplaySet<T> {
+    fn from_iter<I: Iterator<T>>(iterator: I) -> SplaySet<T> {
+        let mut set = SplaySet::new();
+        set.extend(iterator);
+        set
+    }
+}
+
+impl<T: Ord> Extend<T> for SplaySet<T> {
+    fn extend<I: Iterator<T>>(&mut self, mut i: I) {
+        for t in i { self.insert(t); }
+    }
+}


### PR DESCRIPTION
I've had a [splay tree implementation][gh] externally, but it seems like this
may be a good new home for it!

[gh]: https://github.com/alexcrichton/splay-rs

This splay tree implementation is not quite of the quality one would expect of a
standard collection because it primarily doesn't implement iteration by
reference. Due to the self-modifying nature of lookups, I'm not 100% sure how to
safely implement iteration at this time, so only consuming iteration is
provided. Otherwise though I've tried to mirror the interface of HashMap as much
as possible in the implementation!

The implementation also leverages very little unsafe code, so it's not the most
efficient implementation by a long shot. Primarily the splay() method is
probably quite a bit larger than it needs to be!