### PR TITLE
Introduce QuickCheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ authors = ["Alexis Beingessner <a.beingessner@gmail.com>",
 
 [dependencies]
 traverse = "*"
-
-
-
-# FIXME rust-lang/rust#20127: Refreshing ICE
+quickcheck = "*"
+quickcheck_macros = "*"
 
 [profile.dev]
 debug = false

--- a/src/blist.rs
+++ b/src/blist.rs
@@ -6,6 +6,8 @@ use std::hash::{Hash, Writer};
 use std::num::Int;
 use traverse::Traversal;
 
+use quickcheck::{Arbitrary, Gen};
+
 /// A skeleton implementation of a BList, based on the [Space-Efficient Linked List]
 /// (http://opendatastructures.org/ods-python/3_3_SEList_Space_Efficient_.html) described in
 /// Open Data Structures.
@@ -24,6 +26,13 @@ pub struct BList<T> {
     list: DList<RingBuf<T>>,
     b: uint,
     len: uint,
+}
+
+impl<T: Arbitrary> Arbitrary for BList<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> BList<T> {
+        let v: Vec<T> = Arbitrary::arbitrary(g);
+        v.into_iter().collect()
+    }
 }
 
 // Constructors

--- a/src/interval_heap.rs
+++ b/src/interval_heap.rs
@@ -3,6 +3,8 @@
 use std::slice;
 use std::default::Default;
 
+use quickcheck::{Arbitrary, Gen};
+
 // An interval heap is a binary tree structure with the following properties:
 //
 // (1) Each node (except possibly the last leaf) contains two values
@@ -131,6 +133,13 @@ fn update_max<T: Ord>(v: &mut [T]) {
 #[deriving(Clone)]
 pub struct IntervalHeap<T> {
     data: Vec<T>
+}
+
+impl<T: Ord + Arbitrary> Arbitrary for IntervalHeap<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> IntervalHeap<T> {
+        let v: Vec<T> = Arbitrary::arbitrary(g);
+        IntervalHeap::from_vec(v)
+    }
 }
 
 impl<T: Ord> Default for IntervalHeap<T> {
@@ -401,4 +410,3 @@ mod test {
     }
 
 } // mod test
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,12 @@
 #![feature(unboxed_closures)]
 #![feature(globs)]
 #![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)] extern crate test;
 extern crate core;
+extern crate quickcheck;
+#[cfg(test)] #[phase(plugin)] extern crate quickcheck_macros;
 extern crate traverse;
 
 
@@ -85,4 +88,3 @@ pub mod trie_set {
 
 
 pub mod proto;
-

--- a/src/proto/dlist.rs
+++ b/src/proto/dlist.rs
@@ -4,6 +4,8 @@ use std::iter;
 use std::fmt::{mod, Show};
 use std::hash::{Hash, Writer};
 
+use quickcheck::{Arbitrary, Gen};
+
 // FIXME(Gankro): Although the internal interface we have here is *safer* than std's DList,
 // it's still by no means safe. Any claims we make here about safety in the internal APIs
 // are complete hand-waving. For now I'm leaving it like this while we work on better solutions.
@@ -108,6 +110,13 @@ pub struct DList<T> {
     len: uint,
     head: Link<T>,
     tail: Raw<T>,
+}
+
+impl<T: Arbitrary> Arbitrary for DList<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> DList<T> {
+        let v: Vec<T> = Arbitrary::arbitrary(g);
+        v.into_iter().collect()
+    }
 }
 
 impl<T> DList<T> {

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -17,6 +17,8 @@ use std::mem::{replace, swap};
 use std::ptr;
 use std::hash::{Writer, Hash};
 
+use quickcheck::{Arbitrary, Gen};
+
 // FIXME(conventions): implement bounded iterators
 // FIXME(conventions): replace rev_iter(_mut) by making iter(_mut) DoubleEnded
 
@@ -141,6 +143,13 @@ use std::hash::{Writer, Hash};
 pub struct TreeMap<K, V> {
     root: Option<Box<TreeNode<K, V>>>,
     length: uint
+}
+
+impl<K: Arbitrary + Ord, V: Arbitrary> Arbitrary for TreeMap<K, V> {
+    fn arbitrary<G: Gen>(g: &mut G) -> TreeMap<K, V> {
+        let v: Vec<(K, V)> = Arbitrary::arbitrary(g);
+        v.into_iter().collect()
+    }
 }
 
 impl<K: PartialEq + Ord, V: PartialEq> PartialEq for TreeMap<K, V> {

--- a/src/trie/map.rs
+++ b/src/trie/map.rs
@@ -15,16 +15,17 @@ use self::TrieNode::*;
 use std::default::Default;
 use std::fmt;
 use std::fmt::Show;
+use std::hash::{Writer, Hash};
 use std::mem::zeroed;
 use std::mem;
 use std::ops::{Slice, SliceMut};
 use std::uint;
 use std::iter;
 use std::ptr;
-use std::hash::{Writer, Hash};
-
 use std::slice::{Iter, IterMut};
 use std::slice;
+
+use quickcheck::{Arbitrary, Gen};
 
 // FIXME(conventions): implement bounded iterators
 // FIXME(conventions): implement into_iter
@@ -110,6 +111,13 @@ enum TrieNode<T> {
     Internal(Box<InternalNode<T>>),
     External(uint, T),
     Nothing
+}
+
+impl<T: Arbitrary> Arbitrary for TrieMap<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> TrieMap<T> {
+        let v: Vec<(uint, T)> = Arbitrary::arbitrary(g);
+        v.into_iter().collect()
+    }
 }
 
 impl<T: PartialEq> PartialEq for TrieMap<T> {

--- a/src/trie/set.rs
+++ b/src/trie/set.rs
@@ -18,6 +18,8 @@ use std::fmt::Show;
 use std::iter::Peekable;
 use std::hash::Hash;
 
+use quickcheck::{Arbitrary, Gen};
+
 use trie_map::{TrieMap, Entries};
 
 /// A set implemented as a radix trie.
@@ -52,6 +54,13 @@ use trie_map::{TrieMap, Entries};
 #[deriving(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TrieSet {
     map: TrieMap<()>
+}
+
+impl Arbitrary for TrieSet {
+    fn arbitrary<G: Gen>(g: &mut G) -> TrieSet {
+        let v: Vec<uint> = Arbitrary::arbitrary(g);
+        v.into_iter().collect()
+    }
 }
 
 impl Show for TrieSet {


### PR DESCRIPTION
This PR is intended to serve as a place to argue for/again adding
a quickcheck dependency to collect-rs. If the final decision is for,
merge it. If against, close.

The primary argument for adding this is that collections tests are
pretty much the ideal use case for quickcheck. There's a lot of tests
that exist right now that just check one special case of a very general
property, and would be more clearly expressed (and with better coverage!)
with a property-based testing framework like quickcheck. This can
greatly improve quality, readability, and coverage of tests for "free".

One argument against is that this adds an unnecessary dependency.

Another is that it makes code and tests harder to pull into libcollections.

Thoughts?