### PR TITLE
update to Rust master

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -70,7 +70,7 @@ pub fn find_rand_n<M, T, I, F>(n: uint,
 {
     // setup
     let mut rng = rand::weak_rng();
-    let mut keys = Vec::from_fn(n, |_| rng.gen::<uint>() % n);
+    let mut keys: Vec<_> = range(0, n).map(|_| rng.gen::<uint>() % n).collect();
 
     for k in keys.iter() {
         insert(map, *k);

--- a/src/interval_heap.rs
+++ b/src/interval_heap.rs
@@ -229,11 +229,11 @@ impl<T: Ord> IntervalHeap<T> {
     pub fn pop_min(&mut self) -> Option<T> {
         match self.data.len() {
             0 => None,
-            1...2 => self.data.swap_remove(0),
+            1...2 => Some(self.data.swap_remove(0)),
             _ => {
                 let res = self.data.swap_remove(0);
                 update_min(self.data.as_mut_slice());
-                res
+                Some(res)
             }
         }
     }
@@ -245,7 +245,7 @@ impl<T: Ord> IntervalHeap<T> {
             _ => {
                 let res = self.data.swap_remove(1);
                 update_max(self.data.as_mut_slice());
-                res
+                Some(res)
             }
         }
     }

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -1511,7 +1511,7 @@ mod test_treemap {
 
             for _ in range(0u, 30) {
                 let r = rng.gen_range(0, ctrl.len());
-                let (key, _) = ctrl.remove(r).unwrap();
+                let (key, _) = ctrl.remove(r);
                 assert!(map.remove(&key).is_some());
                 check_structure(&map);
                 check_equal(ctrl.as_slice(), &map);


### PR DESCRIPTION
- `Vec::{remove,swap_remove}` now return `T` instead of `Option<T>`
- `Vec::from_fn` was deprecated