### PR TITLE
impl Send and Sync for LruCache

### DIFF
--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -359,6 +359,10 @@ impl<A: fmt::Show + Hash + Eq, B: fmt::Show> fmt::Show for LruCache<A, B> {
     }
 }
 
+unsafe impl<K: Send, V: Send> Send for LruCache<K, V> {}
+
+unsafe impl<K: Sync, V: Sync> Sync for LruCache<K, V> {}
+
 #[unsafe_destructor]
 impl<K, V> Drop for LruCache<K, V> {
     fn drop(&mut self) {


### PR DESCRIPTION
There's no reason `LruCache` can't be Send/Sync so long as both `K` and `V` are.

There are two ways to approach the problem: converting all `*mut`'s used by `LruCache` to `Unique`'s, or impl'ing `Send` and `Sync` for `LruCache` with the appropriate bounds on `K` and `V`.  I ran into a couple of interesting issues while attempting to implement the former solution, and the latter is much cleaner (and was suggested by @cgaebel besides.).

Closes #47.