### PR TITLE
Remove unused import

### DIFF
--- a/src/blist.rs
+++ b/src/blist.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 use std::collections::{ring_buf, RingBuf};
 use std::iter;
 use std::fmt;
-use std::mem;
 use std::hash::{Hash, Hasher, Writer};
 use std::num::Int;
 use traverse::Traversal;


### PR DESCRIPTION
After Gankro's fixes in blist, it doesn't use `std::mem` anymore.