### PR TITLE
Reorganize `tree::map` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,9 @@ extern crate traverse;
 #[cfg(feature="trie_map")] pub use trie_set::TrieSet;
 
 // privates
+#[cfg(test)] #[macro_use] mod bench;
 #[cfg(feature="tree_map")] mod tree;
 #[cfg(feature="trie_map")] mod trie;
-#[cfg(test)] mod bench;
 
 // publics
 

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -594,6 +594,108 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
         node::traverse_mut(&mut self.root, |node| f(node.key()))
             .as_mut().map(|node| node.value_mut())
     }
+
+    /// Returns a reference to the map's maximum key and a reference to its corresponding
+    /// value, or `None` if the map is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use collect::TreeMap;
+    ///
+    /// let mut map = TreeMap::new();
+    /// assert!(map.max().is_none());
+    ///
+    /// map.insert(1, "a");
+    /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    ///
+    /// assert_eq!(map.max(), Some((&3, &"c")));
+    /// ```
+    pub fn max(&self) -> Option<(&K, &V)> {
+        node::traverse(&self.root, node::max)
+            .as_ref().map(|node| (node.key(), node.value()))
+    }
+
+    /// Returns a reference to the map's maximum key and a mutable reference to its
+    /// corresponding value, or `None` if the map is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use collect::TreeMap;
+    ///
+    /// let mut map = TreeMap::new();
+    /// assert!(map.max_mut().is_none());
+    ///
+    /// map.insert(1, "a");
+    /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    ///
+    /// {
+    ///     let max = map.max_mut().unwrap();
+    ///     assert_eq!(max.0, &3);
+    ///     assert_eq!(max.1, &"c");
+    ///     *max.1 = "d";
+    /// }
+    ///
+    /// assert_eq!(map[3], "d");
+    /// ```
+    pub fn max_mut(&mut self) -> Option<(&K, &mut V)> {
+        node::traverse_mut(&mut self.root, node::max)
+            .as_mut().map(|node| node.key_value_mut())
+    }
+
+    /// Returns a reference to the map's minimum key and a reference to its corresponding
+    /// value, or `None` if the map is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use collect::TreeMap;
+    ///
+    /// let mut map = TreeMap::new();
+    /// assert!(map.min().is_none());
+    ///
+    /// map.insert(1, "a");
+    /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    ///
+    /// assert_eq!(map.min(), Some((&1, &"a")));
+    /// ```
+    pub fn min(&self) -> Option<(&K, &V)> {
+        node::traverse(&self.root, node::min)
+            .as_ref().map(|node| (node.key(), node.value()))
+    }
+
+    /// Returns a reference to the map's minimum key and a mutable reference to its
+    /// corresponding value, or `None` if the map is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use collect::TreeMap;
+    ///
+    /// let mut map = TreeMap::new();
+    /// assert!(map.min_mut().is_none());
+    ///
+    /// map.insert(1, "a");
+    /// map.insert(3, "c");
+    /// map.insert(2, "b");
+    ///
+    /// {
+    ///     let min = map.min_mut().unwrap();
+    ///     assert_eq!(min.0, &1);
+    ///     assert_eq!(min.1, &"a");
+    ///     *min.1 = "aa";
+    /// }
+    ///
+    /// assert_eq!(map[1], "aa");
+    /// ```
+    pub fn min_mut(&mut self) -> Option<(&K, &mut V)> {
+        node::traverse_mut(&mut self.root, node::min)
+            .as_mut().map(|node| node.key_value_mut())
+    }
 }
 
 impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -12,9 +12,8 @@ use std::default::Default;
 use std::cmp::Ordering::{self, Less, Equal, Greater};
 use std::fmt::{self, Debug};
 use std::iter::{self, IntoIterator};
-use std::mem::{replace, swap};
+use std::mem::{replace, swap, transmute};
 use std::ops;
-use std::ptr;
 use std::hash::{Hash, Hasher};
 
 use compare::{Compare, Natural, natural};
@@ -277,12 +276,7 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter(&self) -> Iter<K, V> {
-        Iter {
-            stack: vec![],
-            node: deref(&self.root),
-            remaining_min: self.length,
-            remaining_max: self.length
-        }
+        Iter { iter: BaseIter::new(as_ref(&self.root), self.length) }
     }
 
     /// Gets a lazy reverse iterator over the key-value pairs in the map, in descending order.
@@ -302,7 +296,7 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// }
     /// ```
     pub fn rev_iter(&self) -> RevIter<K, V> {
-        RevIter{iter: self.iter()}
+        RevIter { iter: BaseIter::new(as_ref(&self.root), self.length) }
     }
 
     /// Gets a lazy forward iterator over the key-value pairs in the
@@ -329,12 +323,7 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
-        IterMut {
-            stack: vec![],
-            node: deref_mut(&mut self.root),
-            remaining_min: self.length,
-            remaining_max: self.length
-        }
+        IterMut { iter: BaseIter::new(as_ref(&self.root), self.length) }
     }
 
     /// Gets a lazy reverse iterator over the key-value pairs in the
@@ -360,7 +349,7 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// assert_eq!(map.get(&"c"), Some(&13));
     /// ```
     pub fn rev_iter_mut(&mut self) -> RevIterMut<K, V> {
-        RevIterMut{iter: self.iter_mut()}
+        RevIterMut { iter: BaseIter::new(as_ref(&self.root), self.length) }
     }
 
     /// Gets a lazy iterator that consumes the treemap.
@@ -379,16 +368,8 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// assert_eq!(vec, vec![("a", 1), ("b", 2), ("c", 3)]);
     /// ```
     #[unstable = "matches collection reform specification, waiting for dust to settle"]
-    pub fn into_iter(self) -> IntoIter<K, V> {
-        let TreeMap { root, length, .. } = self;
-        let stk = match root {
-            None => vec![],
-            Some(box tn) => vec![tn]
-        };
-        IntoIter {
-            stack: stk,
-            remaining: length
-        }
+    pub fn into_iter(mut self) -> IntoIter<K, V> {
+        IntoIter { iter: BaseIter::new(self.root.take(), self.length) }
     }
 
     /// Return the number of elements in the map.
@@ -617,49 +598,28 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     }
 }
 
-// range iterators.
+impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
+    fn bound<Q: ?Sized>(&self, key: &Q, lower: bool)
+        -> BaseIter<&TreeNode<K, V>, (usize, usize), Forward> where C: Compare<Q, K> {
 
-macro_rules! bound_setup {
-    // initialiser of the iterator to manipulate
-    ($iter:expr, $k:expr,
-     // whether we are looking for the lower or upper bound.
-     $is_lower_bound:expr) => {
-        {
-            let (mut iter, cmp) = $iter;
-            loop {
-                if !iter.node.is_null() {
-                    let node_k = unsafe {&(*iter.node).key};
-                    match Compare::compare(cmp, $k, node_k) {
-                        Less => iter.traverse_left(),
-                        Greater => iter.traverse_right(),
-                        Equal => {
-                            if $is_lower_bound {
-                                iter.traverse_complete();
-                                return iter;
-                            } else {
-                                iter.traverse_right()
-                            }
-                        }
-                    }
-                } else {
-                    iter.traverse_complete();
-                    return iter;
-                }
+        let mut iter = BaseIter::new(as_ref(&self.root), (0, self.length));
+
+        loop {
+            let order = if let Some(ref node) = iter.node {
+                Compare::compare(&self.cmp, key, &node.key)
+            } else {
+                break;
+            };
+
+            match order {
+                Less => iter.traverse_left(),
+                Greater => iter.traverse_right(),
+                Equal => if lower { break } else { iter.traverse_right() },
             }
         }
-    }
-}
 
-impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
-    /// Gets a lazy iterator that should be initialized using
-    /// `traverse_left`/`traverse_right`/`traverse_complete`.
-    fn iter_for_traversal(&self) -> (Iter<K, V>, &C) {
-        (Iter {
-            stack: vec![],
-            node: deref(&self.root),
-            remaining_min: 0,
-            remaining_max: self.length
-        }, &self.cmp)
+        iter.traverse_complete();
+        iter
     }
 
     /// Returns a lazy iterator to the first key-value pair whose key is not less than `k`
@@ -680,41 +640,10 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// assert_eq!(map.lower_bound(&5).next(), Some((&6, &"c")));
     /// assert_eq!(map.lower_bound(&10).next(), None);
     /// ```
-    pub fn lower_bound<Q: ?Sized>(&self, k: &Q) -> Iter<K, V> where C: Compare<Q, K> {
-        bound_setup!(self.iter_for_traversal(), k, true)
-    }
+    pub fn lower_bound<Q: ?Sized>(&self, key: &Q) -> BoundIter<K, V>
+        where C: Compare<Q, K> {
 
-    /// Returns a lazy iterator to the first key-value pair whose key is greater than `k`
-    /// If all keys in map are less than or equal to `k` an empty iterator is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use collect::TreeMap;
-    ///
-    /// let mut map = TreeMap::new();
-    /// map.insert(2, "a");
-    /// map.insert(4, "b");
-    /// map.insert(6, "c");
-    /// map.insert(8, "d");
-    ///
-    /// assert_eq!(map.upper_bound(&4).next(), Some((&6, &"c")));
-    /// assert_eq!(map.upper_bound(&5).next(), Some((&6, &"c")));
-    /// assert_eq!(map.upper_bound(&10).next(), None);
-    /// ```
-    pub fn upper_bound<Q: ?Sized>(&self, k: &Q) -> Iter<K, V> where C: Compare<Q, K> {
-        bound_setup!(self.iter_for_traversal(), k, false)
-    }
-
-    /// Gets a lazy iterator that should be initialized using
-    /// `traverse_left`/`traverse_right`/`traverse_complete`.
-    fn iter_mut_for_traversal(&mut self) -> (IterMut<K, V>, &C) {
-        (IterMut {
-            stack: vec![],
-            node: deref_mut(&mut self.root),
-            remaining_min: 0,
-            remaining_max: self.length
-        }, &self.cmp)
+        BoundIter { iter: self.bound(key, true) }
     }
 
     /// Returns a lazy value iterator to the first key-value pair (with
@@ -747,8 +676,34 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// assert_eq!(map.get(&6), Some(&"changed"));
     /// assert_eq!(map.get(&8), Some(&"changed"));
     /// ```
-    pub fn lower_bound_mut<Q: ?Sized>(&mut self, k: &Q) -> IterMut<K, V> where C: Compare<Q, K> {
-        bound_setup!(self.iter_mut_for_traversal(), k, true)
+    pub fn lower_bound_mut<Q: ?Sized>(&mut self, key: &Q) -> BoundIterMut<K, V>
+        where C: Compare<Q, K> {
+
+        BoundIterMut { iter: self.bound(key, true) }
+    }
+
+    /// Returns a lazy iterator to the first key-value pair whose key is greater than `k`
+    /// If all keys in map are less than or equal to `k` an empty iterator is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use collect::TreeMap;
+    ///
+    /// let mut map = TreeMap::new();
+    /// map.insert(2, "a");
+    /// map.insert(4, "b");
+    /// map.insert(6, "c");
+    /// map.insert(8, "d");
+    ///
+    /// assert_eq!(map.upper_bound(&4).next(), Some((&6, &"c")));
+    /// assert_eq!(map.upper_bound(&5).next(), Some((&6, &"c")));
+    /// assert_eq!(map.upper_bound(&10).next(), None);
+    /// ```
+    pub fn upper_bound<Q: ?Sized>(&self, key: &Q) -> BoundIter<K, V>
+        where C: Compare<Q, K> {
+
+        BoundIter { iter: self.bound(key, false) }
     }
 
     /// Returns a lazy iterator to the first key-value pair (with the
@@ -781,58 +736,255 @@ impl<K, V, C> TreeMap<K, V, C> where C: Compare<K> {
     /// assert_eq!(map.get(&6), Some(&"changed"));
     /// assert_eq!(map.get(&8), Some(&"changed"));
     /// ```
-    pub fn upper_bound_mut<Q: ?Sized>(&mut self, k: &Q) -> IterMut<K, V> where C: Compare<Q, K> {
-        bound_setup!(self.iter_mut_for_traversal(), k, false)
+    pub fn upper_bound_mut<Q: ?Sized>(&mut self, key: &Q) -> BoundIterMut<K, V>
+        where C: Compare<Q, K> {
+
+        BoundIterMut { iter: self.bound(key, false) }
     }
 }
 
-/// Lazy forward iterator over a map
-pub struct Iter<'a, K:'a, V:'a> {
-    stack: Vec<&'a TreeNode<K, V>>,
-    // See the comment on IterMut; this is just to allow
-    // code-sharing (for this immutable-values iterator it *could* very
-    // well be Option<&'a TreeNode<K,V>>).
-    node: *const TreeNode<K, V>,
-    remaining_min: usize,
-    remaining_max: usize
+trait Dir {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef;
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef;
 }
 
-/// Lazy backward iterator over a map
-pub struct RevIter<'a, K:'a, V:'a> {
-    iter: Iter<'a, K, V>,
+enum Forward {}
+
+impl Dir for Forward {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef { node.left() }
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef { node.right() }
 }
+
+enum Reverse {}
+
+impl Dir for Reverse {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef { node.right() }
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef { node.left() }
+}
+
+trait NodeRef {
+    type Item;
+
+    fn left(&mut self) -> Option<Self>;
+    fn right(&mut self) -> Option<Self>;
+
+    fn item(self) -> Self::Item;
+}
+
+fn as_ref<K, V>(node: &Option<Box<TreeNode<K, V>>>) -> Option<&TreeNode<K, V>> {
+    node.as_ref().map(|node| &**node)
+}
+
+impl<'a, K, V> NodeRef for &'a TreeNode<K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn left(&mut self) -> Option<&'a TreeNode<K, V>> { as_ref(&self.left) }
+    fn right(&mut self) -> Option<&'a TreeNode<K, V>> { as_ref(&self.right) }
+
+    fn item(self) -> (&'a K, &'a V) { (&self.key, &self.value) }
+}
+
+impl<K, V> NodeRef for Box<TreeNode<K, V>> {
+    type Item = (K, V);
+
+    fn left(&mut self) -> Option<Box<TreeNode<K, V>>> { self.left.take() }
+    fn right(&mut self) -> Option<Box<TreeNode<K, V>>> { self.right.take() }
+
+    fn item(self) -> (K, V) {
+        let node = *self;
+        (node.key, node.value)
+    }
+}
+
+trait IterSize {
+    fn decrement(&mut self);
+
+    fn get(&self) -> (usize, Option<usize>);
+}
+
+impl IterSize for usize {
+    fn decrement(&mut self) { *self -= 1; }
+
+    fn get(&self) -> (usize, Option<usize>) { (*self, Some(*self)) }
+}
+
+impl IterSize for (usize, usize) {
+    fn decrement(&mut self) {
+        use std::num::Int;
+        self.1 -= 1;
+        self.0 = self.0.saturating_sub(1);
+    }
+
+    fn get(&self) -> (usize, Option<usize>) { (self.0, Some(self.1)) }
+}
+
+struct BaseIter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    stack: Vec<N>,
+    node: Option<N>,
+    size: S,
+}
+
+impl<N, S, D> BaseIter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    fn new(node: Option<N>, size: S) -> BaseIter<N, S, D> {
+        BaseIter { stack: vec![], node: node, size: size }
+    }
+
+    fn traverse_left(&mut self) {
+        let mut node = self.node.take().unwrap();
+        self.node = node.left();
+        self.stack.push(node);
+    }
+
+    fn traverse_right(&mut self) {
+        let mut node = self.node.take().unwrap();
+        self.node = node.right();
+    }
+
+    fn traverse_complete(&mut self) {
+        if let Some(node) = self.node.take() {
+            self.stack.push(node);
+        }
+    }
+}
+
+impl<N, S, D> Clone for BaseIter<N, S, D>
+    where N: Clone + NodeRef, S: Clone + IterSize, D: Dir {
+
+    fn clone(&self) -> BaseIter<N, S, D> {
+        BaseIter {
+            stack: self.stack.clone(),
+            node: self.node.clone(),
+            size: self.size.clone(),
+        }
+    }
+}
+
+impl<N, S, D> Iterator for BaseIter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    type Item = <N as NodeRef>::Item;
+
+    fn next(&mut self) -> Option<<N as NodeRef>::Item> {
+        while let Some(mut node) = self.node.take() {
+            self.node = <D as Dir>::pre(&mut node);
+            self.stack.push(node);
+        }
+
+        self.stack.pop().map(|mut node| {
+            self.node = <D as Dir>::post(&mut node);
+            self.size.decrement();
+            node.item()
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.size.get() }
+}
+
+/// Lazy forward iterator over a map
+pub struct Iter<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, usize, Forward>,
+}
+
+impl<'a, K, V> Clone for Iter<'a, K, V> {
+    fn clone(&self) -> Iter<'a, K, V> { Iter { iter: self.iter.clone() } }
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<(&'a K, &'a V)> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {}
 
 /// Lazy forward iterator over a map that allows for the mutation of
 /// the values.
-pub struct IterMut<'a, K:'a, V:'a> {
-    stack: Vec<&'a mut TreeNode<K, V>>,
-    // Unfortunately, we require some unsafe-ness to get around the
-    // fact that we would be storing a reference *into* one of the
-    // nodes in the stack.
-    //
-    // As far as the compiler knows, this would let us invalidate the
-    // reference by assigning a new value to this node's position in
-    // its parent, which would cause this current one to be
-    // deallocated so this reference would be invalid. (i.e. the
-    // compilers complaints are 100% correct.)
-    //
-    // However, as far as you humans reading this code know (or are
-    // about to know, if you haven't read far enough down yet), we are
-    // only reading from the TreeNode.{left,right} fields. the only
-    // thing that is ever mutated is the .value field (although any
-    // actual mutation that happens is done externally, by the
-    // iterator consumer). So, don't be so concerned, rustc, we've got
-    // it under control.
-    //
-    // (This field can legitimately be null.)
-    node: *mut TreeNode<K, V>,
-    remaining_min: usize,
-    remaining_max: usize
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, usize, Forward>,
+}
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
+        let next = self.iter.next();
+        unsafe { transmute(next) }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 /// Lazy backward iterator over a map
-pub struct RevIterMut<'a, K:'a, V:'a> {
-    iter: IterMut<'a, K, V>,
+pub struct RevIter<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, usize, Reverse>,
+}
+
+impl<'a, K, V> Clone for RevIter<'a, K, V> {
+    fn clone(&self) -> RevIter<'a, K, V> { RevIter { iter: self.iter.clone() } }
+}
+
+impl<'a, K, V> Iterator for RevIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<(&'a K, &'a V)> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+impl<'a, K, V> ExactSizeIterator for RevIter<'a, K, V> {}
+
+/// Lazy backward iterator over a map
+pub struct RevIterMut<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, usize, Reverse>,
+}
+
+impl<'a, K, V> Iterator for RevIterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
+        let next = self.iter.next();
+        unsafe { transmute(next) }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+pub struct IntoIter<K, V> {
+    iter: BaseIter<Box<TreeNode<K, V>>, usize, Forward>,
+}
+
+impl<K, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+    fn next(&mut self) -> Option<(K, V)> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
+
+pub struct BoundIter<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, (usize, usize), Forward>,
+}
+
+impl<'a, K, V> Clone for BoundIter<'a, K, V> {
+    fn clone(&self) -> BoundIter<'a, K, V> { BoundIter { iter: self.iter.clone() } }
+}
+
+impl<'a, K, V> Iterator for BoundIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a V)> { self.iter.next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+pub struct BoundIterMut<'a, K: 'a, V: 'a> {
+    iter: BaseIter<&'a TreeNode<K, V>, (usize, usize), Forward>,
+}
+
+impl<'a, K, V> Iterator for BoundIterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
+        let next = self.iter.next();
+        unsafe { transmute(next) }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 /// TreeMap keys iterator.
@@ -842,218 +994,6 @@ pub struct Keys<'a, K: 'a, V: 'a>
 /// TreeMap values iterator.
 pub struct Values<'a, K: 'a, V: 'a>
     (iter::Map<Iter<'a, K, V>, fn((&'a K, &'a V)) -> &'a V>);
-
-// FIXME #5846 we want to be able to choose between &x and &mut x
-// (with many different `x`) below, so we need to optionally pass mut
-// as a tt, but the only thing we can do with a `tt` is pass them to
-// other macros, so this takes the `& <mutability> <operand>` token
-// sequence and forces their evaluation as an expression.
-macro_rules! addr { ($e:expr) => { $e }}
-// putting an optional mut into type signatures
-macro_rules! item { ($i:item) => { $i }}
-
-macro_rules! define_iterator {
-    ($name:ident,
-     $rev_name:ident,
-
-     // the function to go from &m Option<Box<TreeNode>> to *m TreeNode
-     deref = $deref:ident,
-
-     // see comment on `addr!`, this is just an optional `mut`, but
-     // there's no support for 0-or-1 repeats.
-     addr_mut = $($addr_mut:tt)*
-     ) => {
-        // private methods on the forward iterator (item!() for the
-        // addr_mut in the next_ return value)
-        item!(impl<'a, K, V> $name<'a, K, V> {
-            #[inline(always)]
-            fn next_(&mut self, forward: bool) -> Option<(&'a K, &'a $($addr_mut)* V)> {
-                loop {
-                    if !self.node.is_null() {
-                        let node = unsafe {addr!(& $($addr_mut)* *self.node)};
-                        {
-                            let next_node = if forward {
-                                addr!(& $($addr_mut)* node.left)
-                            } else {
-                                addr!(& $($addr_mut)* node.right)
-                            };
-                            self.node = $deref(next_node);
-                        }
-                        self.stack.push(node);
-                    } else {
-                        return self.stack.pop().map(|node| {
-                            let next_node = if forward {
-                                addr!(& $($addr_mut)* node.right)
-                            } else {
-                                addr!(& $($addr_mut)* node.left)
-                            };
-                            self.node = $deref(next_node);
-                            self.remaining_max -= 1;
-                            if self.remaining_min > 0 {
-                                self.remaining_min -= 1;
-                            }
-                            (&node.key, addr!(& $($addr_mut)* node.value))
-                        });
-                    }
-                }
-            }
-
-            /// traverse_left, traverse_right and traverse_complete are
-            /// used to initialize Iter/IterMut
-            /// pointing to element inside tree structure.
-            ///
-            /// They should be used in following manner:
-            ///   - create iterator using TreeMap::[mut_]iter_for_traversal
-            ///   - find required node using `traverse_left`/`traverse_right`
-            ///     (current node is `Iter::node` field)
-            ///   - complete initialization with `traverse_complete`
-            ///
-            /// After this, iteration will start from `self.node`.  If
-            /// `self.node` is None iteration will start from last
-            /// node from which we traversed left.
-            #[inline]
-            fn traverse_left(&mut self) {
-                let node = unsafe {addr!(& $($addr_mut)* *self.node)};
-                self.node = $deref(addr!(& $($addr_mut)* node.left));
-                self.stack.push(node);
-            }
-
-            #[inline]
-            fn traverse_right(&mut self) {
-                let node = unsafe {addr!(& $($addr_mut)* *self.node)};
-                self.node = $deref(addr!(& $($addr_mut)* node.right));
-            }
-
-            #[inline]
-            fn traverse_complete(&mut self) {
-                if !self.node.is_null() {
-                    unsafe {
-                        self.stack.push(addr!(& $($addr_mut)* *self.node));
-                    }
-                    self.node = ptr::null_mut();
-                }
-            }
-        });
-
-        // the forward Iterator impl.
-        item!(impl<'a, K, V> Iterator for $name<'a, K, V> {
-            type Item = (&'a K, &'a $($addr_mut)* V);
-            /// Advances the iterator to the next node (in order) and return a
-            /// tuple with a reference to the key and value. If there are no
-            /// more nodes, return `None`.
-            fn next(&mut self) -> Option<(&'a K, &'a $($addr_mut)* V)> {
-                self.next_(true)
-            }
-
-            #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                (self.remaining_min, Some(self.remaining_max))
-            }
-        });
-
-        // the reverse Iterator impl.
-        item!(impl<'a, K, V> Iterator for $rev_name<'a, K, V> {
-            type Item = (&'a K, &'a $($addr_mut)* V);
-            fn next(&mut self) -> Option<(&'a K, &'a $($addr_mut)* V)> {
-                self.iter.next_(false)
-            }
-
-            #[inline]
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                self.iter.size_hint()
-            }
-        });
-    }
-} // end of define_iterator
-
-define_iterator! {
-    Iter,
-    RevIter,
-    deref = deref,
-
-    // immutable, so no mut
-    addr_mut =
-}
-define_iterator! {
-    IterMut,
-    RevIterMut,
-    deref = deref_mut,
-
-    addr_mut = mut
-}
-
-fn deref<K, V>(node: &Option<Box<TreeNode<K, V>>>) -> *const TreeNode<K, V> {
-    match *node {
-        Some(ref n) => {
-            let n: &TreeNode<K, V> = &**n;
-            n as *const TreeNode<K, V>
-        }
-        None => ptr::null()
-    }
-}
-
-fn deref_mut<K, V>(x: &mut Option<Box<TreeNode<K, V>>>)
-             -> *mut TreeNode<K, V> {
-    match *x {
-        Some(ref mut n) => {
-            let n: &mut TreeNode<K, V> = &mut **n;
-            n as *mut TreeNode<K, V>
-        }
-        None => ptr::null_mut()
-    }
-}
-
-/// Lazy forward iterator over a map that consumes the map while iterating
-pub struct IntoIter<K, V> {
-    stack: Vec<TreeNode<K, V>>,
-    remaining: usize
-}
-
-impl<K, V> Iterator for IntoIter<K,V> {
-    type Item = (K, V);
-    #[inline]
-    fn next(&mut self) -> Option<(K, V)> {
-        while !self.stack.is_empty() {
-            let TreeNode {
-                key,
-                value,
-                left,
-                right,
-                level,
-            } = self.stack.pop().unwrap();
-
-            match left {
-                Some(box left) => {
-                    let n = TreeNode {
-                        key: key,
-                        value: value,
-                        left: None,
-                        right: right,
-                        level: level
-                    };
-                    self.stack.push(n);
-                    self.stack.push(left);
-                }
-                None => {
-                    match right {
-                        Some(box right) => self.stack.push(right),
-                        None => ()
-                    }
-                    self.remaining -= 1;
-                    return Some((key, value))
-                }
-            }
-        }
-        None
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.remaining, Some(self.remaining))
-    }
-}
-
-impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
 
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -1053,6 +1053,8 @@ impl<K, V> Iterator for IntoIter<K,V> {
     }
 }
 
+impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
+
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
     #[inline] fn next(&mut self) -> Option<&'a K> { self.0.next() }

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -1984,4 +1984,28 @@ mod bench {
     pub fn iter_100000(b: &mut Bencher) {
         bench_iter(b, 100000);
     }
+
+    fn bench_lower_bound(b: &mut Bencher, size: u32) {
+        let mut map = TreeMap::<u32, u32>::new();
+        find_seq_n(size, &mut map, b,
+                   |m, i| { m.insert(i, 1); },
+                   |m, i| for entry in m.lower_bound(&i) {
+                       black_box(entry);
+                   });
+    }
+
+    #[bench]
+    pub fn lower_bound_20(b: &mut Bencher) {
+        bench_lower_bound(b, 20);
+    }
+
+    #[bench]
+    pub fn lower_bound_1000(b: &mut Bencher) {
+        bench_lower_bound(b, 1000);
+    }
+
+    #[bench]
+    pub fn lower_bound_100000(b: &mut Bencher) {
+        bench_lower_bound(b, 100000);
+    }
 }

--- a/src/tree/map.rs
+++ b/src/tree/map.rs
@@ -1550,74 +1550,21 @@ mod bench {
     use test::{Bencher, black_box};
 
     use super::TreeMap;
-    use bench::{insert_rand_n, insert_seq_n, find_rand_n, find_seq_n};
 
-    #[bench]
-    pub fn insert_rand_100(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        insert_rand_n(100, &mut m, b,
-                      |m, i| { m.insert(i, 1); },
-                      |m, i| { m.remove(&i); });
-    }
+    map_insert_rand_bench!{insert_rand_100,    100,    TreeMap}
+    map_insert_rand_bench!{insert_rand_10_000, 10_000, TreeMap}
 
-    #[bench]
-    pub fn insert_rand_10_000(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        insert_rand_n(10_000, &mut m, b,
-                      |m, i| { m.insert(i, 1); },
-                      |m, i| { m.remove(&i); });
-    }
+    map_insert_seq_bench!{insert_seq_100,    100,    TreeMap}
+    map_insert_seq_bench!{insert_seq_10_000, 10_000, TreeMap}
 
-    // Insert seq
-    #[bench]
-    pub fn insert_seq_100(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        insert_seq_n(100, &mut m, b,
-                     |m, i| { m.insert(i, 1); },
-                     |m, i| { m.remove(&i); });
-    }
+    map_find_rand_bench!{find_rand_100,    100,    TreeMap, get}
+    map_find_rand_bench!{find_rand_10_000, 10_000, TreeMap, get}
 
-    #[bench]
-    pub fn insert_seq_10_000(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        insert_seq_n(10_000, &mut m, b,
-                     |m, i| { m.insert(i, 1); },
-                     |m, i| { m.remove(&i); });
-    }
+    map_find_seq_bench!{find_seq_100,    100,    TreeMap, get}
+    map_find_seq_bench!{find_seq_10_000, 10_000, TreeMap, get}
 
-    // Find rand
-    #[bench]
-    pub fn find_rand_100(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        find_rand_n(100, &mut m, b,
-                    |m, i| { m.insert(i, 1); },
-                    |m, i| { m.get(&i); });
-    }
-
-    #[bench]
-    pub fn find_rand_10_000(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        find_rand_n(10_000, &mut m, b,
-                    |m, i| { m.insert(i, 1); },
-                    |m, i| { m.get(&i); });
-    }
-
-    // Find seq
-    #[bench]
-    pub fn find_seq_100(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        find_seq_n(100, &mut m, b,
-                   |m, i| { m.insert(i, 1); },
-                   |m, i| { m.get(&i); });
-    }
-
-    #[bench]
-    pub fn find_seq_10_000(b: &mut Bencher) {
-        let mut m: TreeMap<u32,u32> = TreeMap::new();
-        find_seq_n(10_000, &mut m, b,
-                   |m, i| { m.insert(i, 1); },
-                   |m, i| { m.get(&i); });
-    }
+    map_find_seq_bench!{lower_bound_100,    100,    TreeMap, lower_bound}
+    map_find_seq_bench!{lower_bound_10_000, 10_000, TreeMap, lower_bound}
 
     fn bench_iter(b: &mut Bencher, size: usize) {
         let mut map = TreeMap::<u32, u32>::new();
@@ -1647,29 +1594,5 @@ mod bench {
     #[bench]
     pub fn iter_100000(b: &mut Bencher) {
         bench_iter(b, 100000);
-    }
-
-    fn bench_lower_bound(b: &mut Bencher, size: u32) {
-        let mut map = TreeMap::<u32, u32>::new();
-        find_seq_n(size, &mut map, b,
-                   |m, i| { m.insert(i, 1); },
-                   |m, i| for entry in m.lower_bound(&i) {
-                       black_box(entry);
-                   });
-    }
-
-    #[bench]
-    pub fn lower_bound_20(b: &mut Bencher) {
-        bench_lower_bound(b, 20);
-    }
-
-    #[bench]
-    pub fn lower_bound_1000(b: &mut Bencher) {
-        bench_lower_bound(b, 1000);
-    }
-
-    #[bench]
-    pub fn lower_bound_100000(b: &mut Bencher) {
-        bench_lower_bound(b, 100000);
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -33,3 +33,5 @@
 
 pub mod map;
 pub mod set;
+
+mod node;

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,0 +1,374 @@
+use std::cmp::Ordering;
+use std::cmp::Ordering::*;
+use std::mem::{self, replace, swap};
+
+use compare::Compare;
+
+// Nodes keep track of their level in the tree, starting at 1 in the
+// leaves and with a red child sharing the level of the parent.
+#[derive(Clone)]
+pub struct Node<K, V> {
+    key: K,
+    value: V,
+    left: Option<Box<Node<K, V>>>,
+    right: Option<Box<Node<K, V>>>,
+    level: usize,
+}
+
+impl<K, V> Node<K, V> {
+    pub fn key(&self) -> &K { &self.key }
+
+    pub fn value(&self) -> &V { &self.value }
+
+    pub fn value_mut(&mut self) -> &mut V { &mut self.value }
+}
+
+impl<K, V> Node<K, V> {
+    #[inline]
+    fn new(key: K, value: V) -> Node<K, V> {
+        Node {key: key, value: value, left: None, right: None, level: 1 }
+    }
+
+    // Remove left horizontal link by rotating right
+    fn skew(&mut self) {
+        if self.left.as_ref().map_or(false, |x| x.level == self.level) {
+            let mut save = self.left.take().unwrap();
+            swap(&mut self.left, &mut save.right); // save.right now None
+            swap(self, &mut save);
+            self.right = Some(save);
+        }
+    }
+
+    // Remove dual horizontal link by rotating left and increasing level of
+    // the parent
+    fn split(&mut self) {
+        if self.right.as_ref().map_or(false,
+          |x| x.right.as_ref().map_or(false, |y| y.level == self.level)) {
+            let mut save = self.right.take().unwrap();
+            swap(&mut self.right, &mut save.left); // save.left now None
+            save.level += 1;
+            swap(self, &mut save);
+            self.left = Some(save);
+        }
+    }
+}
+
+pub fn traverse<K, V, F>(mut node: &Option<Box<Node<K, V>>>, mut f: F)
+    -> &Option<Box<Node<K, V>>> where F: FnMut(&Node<K, V>) -> Ordering {
+
+    while let Some(ref r) = *node {
+        node = match f(r) {
+            Less => &r.left,
+            Greater => &r.right,
+            Equal => break,
+        };
+    }
+
+    node
+}
+
+pub fn traverse_mut<K, V, F>(node: &mut Option<Box<Node<K, V>>>, f: F)
+    -> &mut Option<Box<Node<K, V>>> where F: FnMut(&Node<K, V>) -> Ordering {
+
+    let node = traverse(node, f);
+    unsafe { mem::transmute(node) }
+}
+
+pub fn insert<K, V, C>(node: &mut Option<Box<Node<K, V>>>, key: K, value: V, cmp: &C)
+    -> Option<V> where C: Compare<K> {
+
+    match *node {
+        Some(ref mut save) => {
+            let old_value = match cmp.compare(&key, &save.key) {
+                Less => insert(&mut save.left, key, value, cmp),
+                Greater => insert(&mut save.right, key, value, cmp),
+                Equal => {
+                    save.key = key;
+                    return Some(replace(&mut save.value, value));
+                }
+            };
+
+            save.skew();
+            save.split();
+            old_value
+        }
+        None => {
+            *node = Some(box Node::new(key, value));
+            None
+        }
+    }
+}
+
+pub fn remove<K, V, C, Q: ?Sized>(node: &mut Option<Box<Node<K, V>>>, key: &Q, cmp: &C)
+    -> Option<V> where C: Compare<Q, K> {
+
+    fn heir_swap<K, V>(node: &mut Box<Node<K, V>>,
+                            child: &mut Option<Box<Node<K, V>>>) {
+        // *could* be done without recursion, but it won't borrow check
+        for x in child.iter_mut() {
+            if x.right.is_some() {
+                heir_swap(node, &mut x.right);
+            } else {
+                swap(&mut node.key, &mut x.key);
+                swap(&mut node.value, &mut x.value);
+            }
+        }
+    }
+
+    match *node {
+      None => {
+        return None; // bottom of tree
+      }
+      Some(ref mut save) => {
+        let (ret, rebalance) = match cmp.compare(key, &save.key) {
+          Less => (remove(&mut save.left, key, cmp), true),
+          Greater => (remove(&mut save.right, key, cmp), true),
+          Equal => {
+            if save.left.is_some() {
+                if save.right.is_some() {
+                    let mut left = save.left.take().unwrap();
+                    if left.right.is_some() {
+                        heir_swap(save, &mut left.right);
+                    } else {
+                        swap(&mut save.key, &mut left.key);
+                        swap(&mut save.value, &mut left.value);
+                    }
+                    save.left = Some(left);
+                    (remove(&mut save.left, key, cmp), true)
+                } else {
+                    let new = save.left.take().unwrap();
+                    let old = replace(save, new);
+                    *save = save.left.take().unwrap();
+                    (Some(old.value), true)
+                }
+            } else if save.right.is_some() {
+                let new = save.right.take().unwrap();
+                let old = replace(save, new);
+                (Some(old.value), true)
+            } else {
+                (None, false)
+            }
+          }
+        };
+
+        if rebalance {
+            let left_level = save.left.as_ref().map_or(0, |x| x.level);
+            let right_level = save.right.as_ref().map_or(0, |x| x.level);
+
+            // re-balance, if necessary
+            if left_level < save.level - 1 || right_level < save.level - 1 {
+                save.level -= 1;
+
+                if right_level > save.level {
+                    let save_level = save.level;
+                    for x in save.right.iter_mut() { x.level = save_level }
+                }
+
+                save.skew();
+
+                for right in save.right.iter_mut() {
+                    right.skew();
+                    for x in right.right.iter_mut() { x.skew(); }
+                }
+
+                save.split();
+                for x in save.right.iter_mut() { x.split(); }
+            }
+
+            return ret;
+        }
+      }
+    }
+    Some(node.take().unwrap().value)
+}
+
+trait Dir {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef;
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef;
+}
+
+pub enum Forward {}
+
+impl Dir for Forward {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef { node.left() }
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef { node.right() }
+}
+
+pub enum Reverse {}
+
+impl Dir for Reverse {
+    fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef { node.right() }
+    fn post<N>(node: &mut N) -> Option<N> where N: NodeRef { node.left() }
+}
+
+trait NodeRef {
+    type Item;
+
+    fn left(&mut self) -> Option<Self>;
+    fn right(&mut self) -> Option<Self>;
+
+    fn item(self) -> Self::Item;
+}
+
+pub fn as_ref<K, V>(node: &Option<Box<Node<K, V>>>) -> Option<&Node<K, V>> {
+    node.as_ref().map(|node| &**node)
+}
+
+impl<'a, K, V> NodeRef for &'a Node<K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn left(&mut self) -> Option<&'a Node<K, V>> { as_ref(&self.left) }
+    fn right(&mut self) -> Option<&'a Node<K, V>> { as_ref(&self.right) }
+
+    fn item(self) -> (&'a K, &'a V) { (&self.key, &self.value) }
+}
+
+impl<K, V> NodeRef for Box<Node<K, V>> {
+    type Item = (K, V);
+
+    fn left(&mut self) -> Option<Box<Node<K, V>>> { self.left.take() }
+    fn right(&mut self) -> Option<Box<Node<K, V>>> { self.right.take() }
+
+    fn item(self) -> (K, V) {
+        let node = *self;
+        (node.key, node.value)
+    }
+}
+
+trait IterSize {
+    fn decrement(&mut self);
+
+    fn get(&self) -> (usize, Option<usize>);
+}
+
+impl IterSize for usize {
+    fn decrement(&mut self) { *self -= 1; }
+
+    fn get(&self) -> (usize, Option<usize>) { (*self, Some(*self)) }
+}
+
+impl IterSize for (usize, usize) {
+    fn decrement(&mut self) {
+        use std::num::Int;
+        self.1 -= 1;
+        self.0 = self.0.saturating_sub(1);
+    }
+
+    fn get(&self) -> (usize, Option<usize>) { (self.0, Some(self.1)) }
+}
+
+pub struct Iter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    stack: Vec<N>,
+    node: Option<N>,
+    size: S,
+}
+
+impl<N, S, D> Iter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    pub fn new(node: Option<N>, size: S) -> Iter<N, S, D> {
+        Iter { stack: vec![], node: node, size: size }
+    }
+}
+
+impl<'a, K, V> Iter<&'a Node<K, V>, (usize, usize), Forward> {
+    pub fn bounded<C, Q: ?Sized>(node: &'a Option<Box<Node<K, V>>>, cmp: C, key: &Q,
+                                 lower: bool, max_size: usize)
+        -> Iter<&'a Node<K, V>, (usize, usize), Forward> where C: Compare<Q, K> {
+
+        let mut iter = Iter::new(as_ref(node), (0, max_size));
+
+        loop {
+            let order = if let Some(ref node) = iter.node {
+                cmp.compare(key, &node.key)
+            } else {
+                break;
+            };
+
+            match order {
+                Less => iter.traverse_left(),
+                Greater => iter.traverse_right(),
+                Equal => if lower { break } else { iter.traverse_right() },
+            }
+        }
+
+        iter.traverse_complete();
+        iter
+    }
+
+    fn traverse_left(&mut self) {
+        let mut node = self.node.take().unwrap();
+        self.node = node.left();
+        self.stack.push(node);
+    }
+
+    fn traverse_right(&mut self) {
+        let mut node = self.node.take().unwrap();
+        self.node = node.right();
+    }
+
+    fn traverse_complete(&mut self) {
+        if let Some(node) = self.node.take() {
+            self.stack.push(node);
+        }
+    }
+}
+
+impl<N, S, D> Clone for Iter<N, S, D>
+    where N: Clone + NodeRef, S: Clone + IterSize, D: Dir {
+
+    fn clone(&self) -> Iter<N, S, D> {
+        Iter {
+            stack: self.stack.clone(),
+            node: self.node.clone(),
+            size: self.size.clone(),
+        }
+    }
+}
+
+impl<N, S, D> Iterator for Iter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
+    type Item = <N as NodeRef>::Item;
+
+    fn next(&mut self) -> Option<<N as NodeRef>::Item> {
+        while let Some(mut node) = self.node.take() {
+            self.node = <D as Dir>::pre(&mut node);
+            self.stack.push(node);
+        }
+
+        self.stack.pop().map(|mut node| {
+            self.node = <D as Dir>::post(&mut node);
+            self.size.decrement();
+            node.item()
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) { self.size.get() }
+}
+
+#[cfg(test)]
+impl<K, V> Node<K, V> where K: Ord {
+    pub fn check_left(&self) {
+        match self.left {
+            Some(ref r) => {
+                assert_eq!(r.key.cmp(&self.key), Less);
+                assert!(r.level == self.level - 1); // left is black
+                r.check_left();
+                r.check_right(false);
+            }
+            None => assert!(self.level == 1), // parent is leaf
+        }
+    }
+
+    pub fn check_right(&self, parent_red: bool) {
+        match self.right {
+            Some(ref r) => {
+                assert_eq!(r.key.cmp(&self.key), Greater);
+                let red = r.level == self.level;
+                if parent_red { assert!(!red) } // no dual horizontal links
+                // Right red or black
+                assert!(red || r.level == self.level - 1);
+                r.check_left();
+                r.check_right(red);
+            }
+            None => assert!(self.level == 1), // parent is leaf
+        }
+    }
+}

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::*;
-use std::mem::{self, replace, swap};
+use std::mem::{replace, swap};
 
 use compare::Compare;
 
@@ -69,11 +69,23 @@ pub fn traverse<K, V, F>(mut node: &Option<Box<Node<K, V>>>, mut f: F)
     node
 }
 
-pub fn traverse_mut<K, V, F>(node: &mut Option<Box<Node<K, V>>>, f: F)
+pub fn traverse_mut<K, V, F>(mut node: &mut Option<Box<Node<K, V>>>, mut f: F)
     -> &mut Option<Box<Node<K, V>>> where F: FnMut(&Node<K, V>) -> Ordering {
 
-    let node = traverse(node, f);
-    unsafe { mem::transmute(node) }
+    loop {
+        let curr = node;
+
+        node = match *curr {
+            None => break,
+            Some(ref mut r) => match f(r) {
+                Less => &mut r.left,
+                Greater => &mut r.right,
+                Equal => break,
+            },
+        };
+    }
+
+    node
 }
 
 pub fn max<K, V>(node: &Node<K, V>) -> Ordering {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -153,14 +153,9 @@ pub fn remove<K, V, C, Q: ?Sized>(node: &mut Option<Box<Node<K, V>>>, key: &Q, c
           Equal => {
             if save.left.is_some() {
                 if save.right.is_some() {
-                    let mut left = save.left.take().unwrap();
-                    if left.right.is_some() {
-                        heir_swap(save, &mut left.right);
-                    } else {
-                        swap(&mut save.key, &mut left.key);
-                        swap(&mut save.value, &mut left.value);
-                    }
-                    save.left = Some(left);
+                    let mut left = save.left.take();
+                    heir_swap(save, &mut left);
+                    save.left = left;
                     (remove(&mut save.left, key, cmp), true)
                 } else {
                     let new = save.left.take().unwrap();

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -21,6 +21,8 @@ impl<K, V> Node<K, V> {
     pub fn value(&self) -> &V { &self.value }
 
     pub fn value_mut(&mut self) -> &mut V { &mut self.value }
+
+    pub fn key_value_mut(&mut self) -> (&K, &mut V) { (&self.key, &mut self.value) }
 }
 
 impl<K, V> Node<K, V> {
@@ -72,6 +74,14 @@ pub fn traverse_mut<K, V, F>(node: &mut Option<Box<Node<K, V>>>, f: F)
 
     let node = traverse(node, f);
     unsafe { mem::transmute(node) }
+}
+
+pub fn max<K, V>(node: &Node<K, V>) -> Ordering {
+    if node.right.is_some() { Greater } else { Equal }
+}
+
+pub fn min<K, V>(node: &Node<K, V>) -> Ordering {
+    if node.left.is_some() { Less } else { Equal }
 }
 
 pub fn insert<K, V, C>(node: &mut Option<Box<Node<K, V>>>, key: K, value: V, cmp: &C)

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::*;
+use std::marker::{MarkerTrait, PhantomData};
 use std::mem::{replace, swap};
 
 use compare::Compare;
@@ -204,7 +205,7 @@ pub fn remove<K, V, C, Q: ?Sized>(node: &mut Option<Box<Node<K, V>>>, key: &Q, c
     Some(node.take().unwrap().value)
 }
 
-trait Dir {
+trait Dir: MarkerTrait {
     fn pre<N>(node: &mut N) -> Option<N> where N: NodeRef;
     fn post<N>(node: &mut N) -> Option<N> where N: NodeRef;
 }
@@ -283,11 +284,12 @@ pub struct Iter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
     stack: Vec<N>,
     node: Option<N>,
     size: S,
+    _dir: PhantomData<*mut D>,
 }
 
 impl<N, S, D> Iter<N, S, D> where N: NodeRef, S: IterSize, D: Dir {
     pub fn new(node: Option<N>, size: S) -> Iter<N, S, D> {
-        Iter { stack: vec![], node: node, size: size }
+        Iter { stack: vec![], node: node, size: size, _dir: PhantomData }
     }
 }
 
@@ -342,6 +344,7 @@ impl<N, S, D> Clone for Iter<N, S, D>
             stack: self.stack.clone(),
             node: self.node.clone(),
             size: self.size.clone(),
+            _dir: PhantomData,
         }
     }
 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -124,15 +124,20 @@ pub fn insert<K, V, C>(node: &mut Option<Box<Node<K, V>>>, key: K, value: V, cmp
 pub fn remove<K, V, C, Q: ?Sized>(node: &mut Option<Box<Node<K, V>>>, key: &Q, cmp: &C)
     -> Option<V> where C: Compare<Q, K> {
 
-    fn heir_swap<K, V>(node: &mut Box<Node<K, V>>,
-                            child: &mut Option<Box<Node<K, V>>>) {
-        // *could* be done without recursion, but it won't borrow check
-        for x in child.iter_mut() {
-            if x.right.is_some() {
-                heir_swap(node, &mut x.right);
-            } else {
-                swap(&mut node.key, &mut x.key);
-                swap(&mut node.value, &mut x.value);
+    fn heir_swap<K, V>(node: &mut Node<K, V>, mut child: &mut Option<Box<Node<K, V>>>) {
+        loop {
+            let curr = child;
+
+            child = match *curr {
+                None => return,
+                Some(ref mut x) =>
+                    if x.right.is_some() {
+                        &mut x.right
+                    } else {
+                        swap(&mut node.key, &mut x.key);
+                        swap(&mut node.value, &mut x.value);
+                        return;
+                    },
             }
         }
     }

--- a/src/tree/set.rs
+++ b/src/tree/set.rs
@@ -637,6 +637,8 @@ impl<T> Iterator for IntoIter<T> {
     #[inline] fn size_hint(&self) -> (usize, Option<usize>) { self.0.size_hint() }
 }
 
+impl<T> ExactSizeIterator for IntoIter<T> {}
+
 impl<'a, T, C> Iterator for Difference<'a, T, C> where C: Compare<T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<&'a T> {

--- a/src/tree/set.rs
+++ b/src/tree/set.rs
@@ -217,8 +217,8 @@ impl<T, C> TreeSet<T, C> where C: Compare<T> {
     /// assert_eq!(set.lower_bound(&10).next(), None);
     /// ```
     #[inline]
-    pub fn lower_bound(&self, v: &T) -> Iter<T> {
-        Iter { iter: self.map.lower_bound(v) }
+    pub fn lower_bound(&self, v: &T) -> BoundIter<T> {
+        BoundIter { iter: self.map.lower_bound(v) }
     }
 
     /// Gets a lazy iterator pointing to the first value greater than `v`.
@@ -236,8 +236,8 @@ impl<T, C> TreeSet<T, C> where C: Compare<T> {
     /// assert_eq!(set.upper_bound(&10).next(), None);
     /// ```
     #[inline]
-    pub fn upper_bound(&self, v: &T) -> Iter<T> {
-        Iter { iter: self.map.upper_bound(v) }
+    pub fn upper_bound(&self, v: &T) -> BoundIter<T> {
+        BoundIter { iter: self.map.upper_bound(v) }
     }
 
     /// Visits the values representing the difference, in ascending order.
@@ -572,6 +572,11 @@ pub struct Iter<'a, T:'a> {
     iter: tree_map::Iter<'a, T, ()>
 }
 
+/// A lazy forward iterator over a set.
+pub struct BoundIter<'a, T: 'a> {
+    iter: tree_map::BoundIter<'a, T, ()>,
+}
+
 /// A lazy backward iterator over a set.
 pub struct RevIter<'a, T:'a> {
     iter: tree_map::RevIter<'a, T, ()>
@@ -618,6 +623,9 @@ fn cmp_opt<T, C: Compare<T>>(x: Option<& &T>, y: Option<& &T>,
     }
 }
 
+impl<'a, T> Clone for Iter<'a, T> {
+    fn clone(&self) -> Iter<'a, T> { Iter { iter: self.iter.clone() } }
+}
 
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
@@ -625,11 +633,29 @@ impl<'a, T> Iterator for Iter<'a, T> {
     #[inline] fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
+impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
+
+impl<'a, T> Clone for BoundIter<'a, T> {
+    fn clone(&self) -> BoundIter<'a, T> { BoundIter { iter: self.iter.clone() } }
+}
+
+impl<'a, T> Iterator for BoundIter<'a, T> {
+    type Item = &'a T;
+    #[inline] fn next(&mut self) -> Option<&'a T> { self.iter.next().map(|(value, _)| value) }
+    #[inline] fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
+}
+
+impl<'a, T> Clone for RevIter<'a, T> {
+    fn clone(&self) -> RevIter<'a, T> { RevIter { iter: self.iter.clone() } }
+}
+
 impl<'a, T> Iterator for RevIter<'a, T> {
     type Item = &'a T;
     #[inline] fn next(&mut self) -> Option<&'a T> { self.iter.next().map(|(value, _)| value) }
     #[inline] fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
+
+impl<'a, T> ExactSizeIterator for RevIter<'a, T> {}
 
 impl<T> Iterator for IntoIter<T> {
     type Item = T;


### PR DESCRIPTION
A lot of the redundant impls could be removed if we used type aliases instead of wrapper types.

Benches:
```
before:
tree::map::bench::iter_1000          :     10601 ns/iter (+/- 599)
tree::map::bench::iter_100000        :   1825796 ns/iter (+/- 271541)
tree::map::bench::iter_20            :       224 ns/iter (+/- 10)

tree::map::bench::lower_bound_1000   :      5261 ns/iter (+/- 206)
tree::map::bench::lower_bound_100000 :   1090768 ns/iter (+/- 268915)
tree::map::bench::lower_bound_20     :       133 ns/iter (+/- 6)

after:
tree::map::bench::iter_1000          :      2823 ns/iter (+/- 186)
tree::map::bench::iter_100000        :   1039052 ns/iter (+/- 243046)
tree::map::bench::iter_20            :        67 ns/iter (+/- 3)

tree::map::bench::lower_bound_1000   :      1674 ns/iter (+/- 86)
tree::map::bench::lower_bound_100000 :    378951 ns/iter (+/- 94456)
tree::map::bench::lower_bound_20     :        52 ns/iter (+/- 4)
```