### PR TITLE
implement `Debug` for `{IntervalHeap,LinearMap}`

### DIFF
--- a/src/interval_heap.rs
+++ b/src/interval_heap.rs
@@ -2,6 +2,7 @@
 
 use std::slice;
 use std::default::Default;
+use std::fmt::{self, Debug};
 use std::iter::{self, IntoIterator};
 
 use compare::{Compare, Natural, natural};
@@ -378,6 +379,21 @@ impl<T, C: Compare<T>> IntervalHeap<T, C> {
                 }),
             _ => true, // 1
         }
+    }
+}
+
+impl<T: Debug, C: Compare<T>> Debug for IntervalHeap<T, C> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "{{"));
+
+        let mut it = self.iter();
+
+        if let Some(item) = it.next() {
+            try!(write!(f, "{:?}", item));
+            for item in it { try!(write!(f, ", {:?}", item)); }
+        }
+
+        write!(f, "}}")
     }
 }
 

--- a/src/proto/linear_map.rs
+++ b/src/proto/linear_map.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 
+use std::fmt::{self, Debug};
 use std::iter::{IntoIterator, Map};
 use std::mem;
 use std::slice;
@@ -308,6 +309,21 @@ impl<'a, K:'a + Eq, V:'a> IntoIterator for &'a mut LinearMap<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
     fn into_iter(self) -> IterMut<'a, K, V> { self.iter_mut() }
+}
+
+impl<K, V> Debug for LinearMap<K, V> where K: Debug + Eq, V: Debug {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(write!(f, "{{"));
+
+        let mut it = self.iter();
+
+        if let Some((k, v)) = it.next() {
+            try!(write!(f, "{:?}: {:?}", k, v));
+            for (k, v) in it { try!(write!(f, ", {:?}: {:?}", k, v)); }
+        }
+
+        write!(f, "}}")
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`ParVec` is still missing a `Debug` implementation. It's tempting to `derive` one, but I'm not sure about the thread-safety implications for that type.

Otherwise, the only types that are missing one are iterators, entries, and cursors. Note that this can be determined using the `missing_debug_implementations` lint.

CC #98.